### PR TITLE
Fix bug in mfe.py

### DIFF
--- a/mfe.py
+++ b/mfe.py
@@ -15,7 +15,7 @@ def mfe(seq, package='vienna_2', T=37,
     dangles=True, noncanonical=False, beam_size=100,
     bpps=False, param_file=None, coaxial=True, reweight=None,viterbi = False,
     probing_signal=None,probing_kws=None,
-    shape_signal=None, dms_signal=None, shape_file=None, dms_file=None, pk=False):
+    shape_signal=None, dms_signal=None, shape_file=None, dms_file=None, pseudoknots=False):
 
     ''' Compute MFE structure (within package) for RNA sequence.
     Note: this is distinct from the arnie MEA codebase, which takes any base pair probability matrix and computes the maximum expected accuracy structure.


### PR DESCRIPTION
Renames the pk argument to pseudoknots. Should fix https://github.com/DasLab/arnie/issues/10.