### PR TITLE
Clean up temporary SHAPE/DMS files generated during bootstrap iterations

### DIFF
--- a/mfe_bootstrap.py
+++ b/mfe_bootstrap.py
@@ -72,6 +72,6 @@ def mfe_bootstrap(seq, num_bootstrap,
         if shape_signal is not None:
             remove(shape_file)
         if dms_signal is not None:
-            os.remove(dms_file)
+            remove(dms_file)
 
     return [mfe_struct, bpp_matrix/num_bootstrap]

--- a/mfe_bootstrap.py
+++ b/mfe_bootstrap.py
@@ -70,7 +70,7 @@ def mfe_bootstrap(seq, num_bootstrap,
         bpp_matrix += get_bpp_from_dbn(cur_mfe_struct)
 
         if shape_signal is not None:
-            os.remove(shape_file)
+            remove(shape_file)
         if dms_signal is not None:
             os.remove(dms_file)
 

--- a/mfe_bootstrap.py
+++ b/mfe_bootstrap.py
@@ -27,7 +27,7 @@ def get_bootstrap_reac_file(reactivity):
 
 def mfe_bootstrap(seq, num_bootstrap, 
     package='rnastructure', T=37,
-    constraint=None, shape_signal=None, dms_signal=None, pk=False):
+    constraint=None, shape_signal=None, dms_signal=None, pseudo=False):
     """
     Compute MFE structure (within package) for RNA sequence with bootstrapping on the SHAPE/DMS data.
 
@@ -37,7 +37,7 @@ def mfe_bootstrap(seq, num_bootstrap,
         constraint (str): structure constraints
         shape_signal(list): list of normalized SHAPE reactivities, with negative values indicating no signal
         dms_signal(list): list of normalized DMS reactivities, with negative values indicating no signal
-        pk: if True, will predict pseudoknots, but only with RNAstructure
+        pseudo: if True, will predict pseudoknots, but only with RNAstructure
 
         Possible packages: 
         'rnastructure'
@@ -54,7 +54,7 @@ def mfe_bootstrap(seq, num_bootstrap,
     bpp_matrix = np.zeros((len(seq), len(seq)))
 
     mfe_struct = mfe(seq, package=package, T=T, constraint=constraint, 
-        shape_signal=shape_signal, dms_signal=dms_signal)
+        shape_signal=shape_signal, dms_signal=dms_signal, pseudo=pseudo)
 
     for bootstrap in range(num_bootstrap):
         shape_file = None
@@ -66,7 +66,12 @@ def mfe_bootstrap(seq, num_bootstrap,
             dms_file = get_bootstrap_reac_file(dms_signal)
 
         cur_mfe_struct = mfe(seq, package=package, T=T, constraint=constraint, 
-            shape_file=shape_file, dms_file=dms_file, pk=pk)
+            shape_file=shape_file, dms_file=dms_file, pseudo=pseudo)
         bpp_matrix += get_bpp_from_dbn(cur_mfe_struct)
+
+        if shape_signal is not None:
+            os.remove(shape_file)
+        if dms_signal is not None:
+            os.remove(dms_file)
 
     return [mfe_struct, bpp_matrix/num_bootstrap]


### PR DESCRIPTION
.SHAPE files generated during bootstrap iterations were not automatically removed.