### PR TITLE
Modify documentation for adding Vienna to arnie file

### DIFF
--- a/docs/setup_doc.md
+++ b/docs/setup_doc.md
@@ -138,6 +138,7 @@ Then set in the arnie file:
 ```
 # Vienna RNAfold 2 Linux build from source:
 vienna_2: /path/to/ViennaRNA-2.4.14/src/bin
+vienna: /path/to/ViennaRNA-2.4.14/src/bin
 ```
 
 ## NUPACK (`package='nupack'`)


### PR DESCRIPTION
RiboTree expects both `vienna` and `vienna_2` to be present as keys in the package dictionary. 