### PR TITLE
Support package definition via environment variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "arnie"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name="Das Lab", email="thedaslab@stanford.edu" },
 ]

--- a/src/arnie/utils.py
+++ b/src/arnie/utils.py
@@ -292,7 +292,6 @@ def load_package_locations(DEBUG=False):
     package_path = os.path.dirname(arnie.__file__)
 
     if DEBUG:
-        print('Reading Arnie file at %s' % os.environ['ARNIEFILE'])
         print(supported_packages)
 
     # Read from environment variables
@@ -304,17 +303,24 @@ def load_package_locations(DEBUG=False):
         path = os.environ.get(envVar)
         if path:
             return_dct[package] = path
+            if DEBUG:
+                print(f'{package}: {path}')
 
     # Read from Arnie file as last resort
-    with open("%s" % os.environ["ARNIEFILE"], 'r') as f:
-        for line in f.readlines():
-            if line.strip():
-                if not line.startswith('#'):
-                    key, string = line.split(':')
-                    string = string.strip()
-                    if key not in return_dct:
-                        return_dct[key] = string
+    if os.environ.get("ARNIEFILE"):
+        if DEBUG:
+            print('Reading Arnie file at %s' % os.environ['ARNIEFILE'])
+        with open("%s" % os.environ["ARNIEFILE"], 'r') as f:
+            for line in f.readlines():
+                if line.strip():
+                    if not line.startswith('#'):
+                        key, string = line.split(':')
+                        string = string.strip()
+                        if key not in return_dct:
+                            return_dct[key] = string
 
+    if not return_dct:
+        raise EnvironmentError("No prediction packages found in your environment. Check your environment variables or your ARNIEFILE.")
     return return_dct
 
 

--- a/src/arnie/utils.py
+++ b/src/arnie/utils.py
@@ -246,9 +246,25 @@ def prob_to_bpp(prob_file):
 
 
 ###############################################################################
-# Package handeling
+# Package handling
 ###############################################################################
 
+supported_packages = [
+    "contrafold",
+    "eternafold",
+    "nupack",
+    "RNAstructure",
+    "RNAsoft",
+    "vienna"
+    # PK Predictors
+    "e2efold",
+    "hotknots", 
+    "ipknot", 
+    "knotty", 
+    "pknots",
+    "spotrna",
+    "spotrna2",
+]
 
 def print_path_files():
     package_dct = load_package_locations()
@@ -271,24 +287,33 @@ def package_list():
 
 
 def load_package_locations(DEBUG=False):
-    '''Read in user-supplied file to specify paths to RNA folding packages. Specify this in your ~/.bashrc as $ARNIEFILE'''
+    '''Set up  paths to RNA folding packages. Checks environment variables or a user-supplied file. If using the file, specify this in your ~/.bashrc as $ARNIEFILE'''
     return_dct = {}
     package_path = os.path.dirname(arnie.__file__)
 
     if DEBUG:
         print('Reading Arnie file at %s' % os.environ['ARNIEFILE'])
+        print(supported_packages)
 
+    # Read from environment variables
+    for package in supported_packages:
+        envVar = f"{package.upper()}_PATH"
+        # Nupack installation sets its own environment variables
+        if package == "nupack":
+            envVar = f"{package.upper()}HOME"
+        path = os.environ.get(envVar)
+        if path:
+            return_dct[package] = path
+
+    # Read from Arnie file as last resort
     with open("%s" % os.environ["ARNIEFILE"], 'r') as f:
         for line in f.readlines():
             if line.strip():
                 if not line.startswith('#'):
                     key, string = line.split(':')
                     string = string.strip()
-                    return_dct[key] = string
-
-    # if 'eternafoldparams' not in return_dct.keys():
-    #   if 'eternafold' in return_dct.keys():
-    #     return_dct['eternafoldparams'] = "%s/../parameters/EternaFoldParams.v1" % return_dct['eternafold']
+                    if key not in return_dct:
+                        return_dct[key] = string
 
     return return_dct
 


### PR DESCRIPTION
`load_package_locations` is used in most arnie functions to find the installed packages. This PR enables `load_package_locations` to also search for specific environment variables that point to installed package paths. This approach operates similarly to the arnie_file, but allows for automatic configuration of some packages, as well
as environment encapsulation (e.g. different environments could have different package versions installed). The arnie_file is still supported for backwards compatibility.
 
#32 + this PR closes #26.