### PR TITLE
Improved conflict resolution in Hungarian (+ remove broken normalization)

### DIFF
--- a/src/arnie/pk_predictors.py
+++ b/src/arnie/pk_predictors.py
@@ -137,11 +137,7 @@ def _hungarian(bpp, exp=1, sigmoid_slope_factor=None, prob_to_0_threshold_prior=
         bpp = _sigmoid(bpp, slope_factor=sigmoid_slope_factor)
 
         # should think about order of above functions and possibly normalize again here
-        # (normalize again we shall...)
-        if add_p_unpaired:
-            row_sums = bpp.sum(axis=1)
-            bpp = bpp / row_sums[:, np.newaxis]
-
+        
         # run hungarian algorithm to find base pairs
     _, row_pairs = linear_sum_assignment(-bpp)
     bp_list = []

--- a/src/arnie/pk_predictors.py
+++ b/src/arnie/pk_predictors.py
@@ -167,6 +167,7 @@ def _hungarian(bpp, exp=1, sigmoid_slope_factor=None, prob_to_0_threshold_prior=
             bps.append(conflict)
             bp_assignments.remove(conflict)
             check_nt = next((nt for nt in conflict if nt != check_nt), None)
+        
         if len(bps) == 1:
             bp_list.extend(bps)
         elif len(bps) > 2 and bps[0][0] in bps[-1] or bps[0][1] in bps[-1]:
@@ -215,7 +216,7 @@ def _max_weight_independent_set(pairs, probs):
                 max_sets.append(max_sets[-1])
             else:
                 max_sets.append({'prob': max_sets[-2]['prob'] + bp_prob, 'bps': [*max_sets[-2]['bps'], bp]})
-    
+
     return (max_sets[-1]['bps'], max_sets[-1]['prob'])
 
 def _sigmoid(x, slope_factor=0.5):


### PR DESCRIPTION
For the row-wise normalization, this was introduced in the wrong place, but also on further discussion with Jeff and tests on RibonanzaNet, it seems like this is likely ineffective/not really correct

For the improved conflict resolution algorithm, we now pick conflicting base pairs based on highest probability where possible, otherwise similar to Threshknot (bp distance then lowest base) where applicable

I tested a number of sample scenarios by hand in an attempt to verify the various conditions here